### PR TITLE
fix: Filter out invalid versions returned by deps.dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ docker/build:
 .PHONY: build
 ## Build the binary.
 build:
-	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o $(BIN_DIR)/$(APP_NAME) $(MAIN_DIR)
+	CGO_ENABLED=0 go build -ldflags=$(LDFLAGS) -o $(BIN_DIR)/$(APP_NAME) $(MAIN_DIR)
 
 .PHONY: release
 ## Build and release the binaries.

--- a/command.go
+++ b/command.go
@@ -114,7 +114,7 @@ func (c Command) runForModule(module *internal.Module) error {
 		}
 		// Try fetching the versions from deps.dev.
 		// Go list does not list prerelease versions, which is fine,
-		// unless we're dealing with with a prerelease version ourselves.
+		// unless we're dealing with a prerelease version ourselves.
 		versions, err = c.fallbackVersions.GetVersions(module.Path)
 		if err != nil {
 			return err

--- a/command.go
+++ b/command.go
@@ -109,7 +109,7 @@ func (c Command) runForModule(module *internal.Module) error {
 	}
 	if len(versions) == 0 {
 		if module.Version.Prerelease() == "" {
-			log.Printf("WARN: module %s does not have any versions", module.Path)
+			log.Printf("WARN: module '%s' does not have any versions", module.Path)
 			return nil
 		}
 		// Try fetching the versions from deps.dev.
@@ -121,7 +121,7 @@ func (c Command) runForModule(module *internal.Module) error {
 		}
 		// Check again.
 		if len(versions) == 0 {
-			log.Printf("WARN: module %s does not have any versions", module.Path)
+			log.Printf("WARN: module '%s' does not have any versions", module.Path)
 			return nil
 		}
 	}

--- a/internal/deps_dev_test.go
+++ b/internal/deps_dev_test.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepsDevClient_GetVersions(t *testing.T) {
+	t.Run("filter out non canonical versions", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`
+{
+  "versions": [
+    {"versionKey": {"version": "v0.0.0-20201216005158-039620a65673"}},
+    {"versionKey": {"version": "v1"}},
+    {"versionKey": {"version": "v1.0.0"}},
+    {"versionKey": {"version": "v1.2"}},
+    {"versionKey": {"version": "v1.2.0"}}
+  ]
+}
+`))
+		}))
+
+		u, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+		client := DepsDevClient{
+			http:   new(http.Client),
+			apiURL: *u,
+		}
+
+		versions, err := client.GetVersions("test")
+		require.NoError(t, err)
+		assert.ElementsMatch(t,
+			[]*semver.Version{
+				semver.MustParse("v0.0.0-20201216005158-039620a65673"),
+				semver.MustParse("v1.0.0"),
+				semver.MustParse("v1.2.0"),
+			},
+			versions)
+	})
+}


### PR DESCRIPTION
Resolves https://github.com/nieomylnieja/go-libyear/issues/14.