### PR TITLE
fix: Use latest version returned by GOPROXY instead of manually finding latest

### DIFF
--- a/internal/go_list.go
+++ b/internal/go_list.go
@@ -49,22 +49,23 @@ func (e *GoListExecutor) GetLatestInfo(path string) (*Module, error) {
 	return e.getInfo(path, nil, true)
 }
 
+// Fetch module details.
 func (e *GoListExecutor) getInfo(path string, version *semver.Version, latest bool) (*Module, error) {
 	var versionStr string
 	if latest {
 		versionStr = "latest"
 	} else {
-		versionStr = version.String()
+		versionStr = "v" + version.String()
 	}
 	// Try loading from cache.
-	if e.cache != nil {
+	if version != nil && e.cache != nil {
 		m, loaded := e.cache.Load(path, version)
 		if loaded {
 			return m, nil
 		}
 	}
 	// Fetch module details.
-	out, err := e.exec(path + "@v" + versionStr)
+	out, err := e.exec(path + "@" + versionStr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/go_proxy.go
+++ b/internal/go_proxy.go
@@ -64,7 +64,7 @@ func (c *GoProxyClient) GetLatestInfo(path string) (*Module, error) {
 
 func (c *GoProxyClient) getInfo(path string, version *semver.Version, latest bool) (*Module, error) {
 	// Try loading from cache.
-	if c.cache != nil {
+	if version != nil && c.cache != nil {
 		m, loaded := c.cache.Load(path, version)
 		if loaded {
 			return m, nil

--- a/internal/module.go
+++ b/internal/module.go
@@ -19,10 +19,10 @@ type Module struct {
 	Version *semver.Version `json:"Version"`
 	Time    time.Time       `json:"Time"`
 
-	IsIndirect bool    `json:"-"`
-	IsFresh    bool    `json:"-"`
-	Latest     *Module `json:"-"`
-	Libyear    float64 `json:"-"`
+	Indirect bool    `json:"-"`
+	Skipped  bool    `json:"-"`
+	Latest   *Module `json:"-"`
+	Libyear  float64 `json:"-"`
 	// ReleasesDiff is the number of release versions between latest and current.
 	ReleasesDiff int `json:"-"`
 	// VersionsDiff is an array of 3 elements: major, minor and patch versions.
@@ -64,9 +64,9 @@ func ReadGoMod(content []byte) (mainModule *Module, modules []*Module, err error
 			return nil, nil, err
 		}
 		modules = append(modules, &Module{
-			Path:       require.Mod.Path,
-			Version:    version,
-			IsIndirect: require.Indirect,
+			Path:     require.Mod.Path,
+			Version:  version,
+			Indirect: require.Indirect,
 		})
 	}
 	if modFile.Module == nil {

--- a/test/inputs/responses.json
+++ b/test/inputs/responses.json
@@ -218,12 +218,17 @@
     "Version": "v1.3.2",
     "Time": "2023-06-08T06:14:45Z"
   },
+  "github.com/!burnt!sushi/toml": {
+    "Path": "github.com/BurntSushi/toml",
+    "Version": "v2.0.0-experimental",
+    "Time": "2021-08-05T05:14:45Z"
+  },
   "github.com/!burnt!sushi/toml/@latest": {
     "Path": "github.com/BurntSushi/toml",
     "Version": "v1.3.2",
     "Time": "2023-06-08T06:14:45Z"
   },
-  "github.com/!burnt!sushi/toml/@v/list": "v0.1.0\nv0.2.0\nv0.3.0\nv0.3.1\nv0.4.0\nv0.4.1\nv1.0.0\nv1.1.0\nv1.2.0\nv1.2.1\nv1.3.0\nv1.3.1\nv1.3.2",
+  "github.com/!burnt!sushi/toml/@v/list": "v0.1.0\nv0.2.0\nv0.3.0\nv0.3.1\nv0.4.0\nv0.4.1\nv1.0.0\nv1.1.0\nv1.2.0\nv1.2.1\nv1.3.0\nv1.3.1\nv1.3.2\nv2.0.0-experimental",
   "github.com/test/test/@latest": "v1.0.0",
   "github.com/test/test/@v/v1.0.0.mod": "./test/inputs/go.mod"
 }


### PR DESCRIPTION
Resolves https://github.com/nieomylnieja/go-libyear/issues/15.

After consideration, I decided to query `@latest` instead of extracting latest from the list of versions.
This way GOPROXY decides what is the latest.