### PR TITLE
chore: Update devbox and turn off govulncheck

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,11 +1,5 @@
 name: Scan vulnerabilities
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   schedule:
     # Run at 8:00 AM every weekday.
     - cron:  '0 8 * * 1-5'

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ test/unit:
 	$(call _print_step,Running unit tests)
 	go test -race -cover ./...
 
-.PHONY: check check/vet check/lint check/gosec check/spell check/trailing check/markdown check/format check/vulns
+.PHONY: check check/vet check/lint check/gosec check/spell check/trailing check/markdown check/format
 ## Run all checks.
-check: check/vet check/lint check/gosec check/spell check/trailing check/markdown check/format check/vulns
+check: check/vet check/lint check/gosec check/spell check/trailing check/markdown check/format
 
 ## Run 'go vet' on the whole project.
 check/vet:

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,182 +2,434 @@
   "lockfile_version": "1",
   "packages": {
     "go@1.22": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#go",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#go",
       "source": "devbox-search",
-      "version": "1.22.1",
+      "version": "1.22.2",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/n1k6wf8q10q7k0863gb78b1rf0j07r7r-go-1.22.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/460vdyz0ghxh8n5ibq3fgc3s63is68cd-go-1.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/460vdyz0ghxh8n5ibq3fgc3s63is68cd-go-1.22.2"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/fl6cjlp5bvykfz1kxrw687zxzld25pn7-go-1.22.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/c732580an83by9405c5j2fmn04hp6ry6-go-1.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/c732580an83by9405c5j2fmn04hp6ry6-go-1.22.2"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/xgdp7gnf6vzr2ick2ip1lhq4cww65p7w-go-1.22.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9cim6f30wrzdbiaw8wa45kvffns73dgz-go-1.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9cim6f30wrzdbiaw8wa45kvffns73dgz-go-1.22.2"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6bvndddvxaypc42x6x4ari20gv3vfdgd-go-1.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6bvndddvxaypc42x6x4ari20gv3vfdgd-go-1.22.2"
         }
       }
     },
     "gofumpt@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#gofumpt",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#gofumpt",
       "source": "devbox-search",
       "version": "0.6.0",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/48bfiba07vnv8crk6c9w1zv1wq4b8xyn-gofumpt-0.6.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ibinwhk2bw2b4i82c2b0w780m12619h3-gofumpt-0.6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ibinwhk2bw2b4i82c2b0w780m12619h3-gofumpt-0.6.0"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/90mmbdn5bbmcrbch92jx46my4d66l65a-gofumpt-0.6.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6jl9sknacabj9pnv0g4rf62adklqjz3s-gofumpt-0.6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6jl9sknacabj9pnv0g4rf62adklqjz3s-gofumpt-0.6.0"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/jhjxvpgil98ragj8qvfbkbr4m70f12v9-gofumpt-0.6.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/d6sbcby89bp6j81hmvbhrhdp5v75kx1v-gofumpt-0.6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/d6sbcby89bp6j81hmvbhrhdp5v75kx1v-gofumpt-0.6.0"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/4n1xhxf8lxs8hc9gzd1kf2zv67scczqw-gofumpt-0.6.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h43q3mrljv95b5a72p32j9cyjrmh8y5d-gofumpt-0.6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/h43q3mrljv95b5a72p32j9cyjrmh8y5d-gofumpt-0.6.0"
         }
       }
     },
     "golangci-lint@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#golangci-lint",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#golangci-lint",
       "source": "devbox-search",
-      "version": "1.57.1",
+      "version": "1.58.1",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/rbkz66qnxvnla1rms6bd6zky1bi62jwc-golangci-lint-1.57.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bydzzbi737n0yz9rnxn22wdsjxkwv1k4-golangci-lint-1.58.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bydzzbi737n0yz9rnxn22wdsjxkwv1k4-golangci-lint-1.58.1"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/r5xyf90x7c91j3r34sg6k9wbf4dm1v4q-golangci-lint-1.57.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fmps18b6vl515cl6qbpifhrz3xy4mj2w-golangci-lint-1.58.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fmps18b6vl515cl6qbpifhrz3xy4mj2w-golangci-lint-1.58.1"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/8yd7j7jcg0sihbrbxnz7drqd6lwlcz6r-golangci-lint-1.57.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fqs3ara0li6dayia401gsl24g4hz6zvh-golangci-lint-1.58.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fqs3ara0li6dayia401gsl24g4hz6zvh-golangci-lint-1.58.1"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/7vvwm8q3zx6xiln6rmdh21mqjccbrd9x-golangci-lint-1.57.1"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1sl15s73cvimib3asgbqsbfrccq0z7cw-golangci-lint-1.58.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1sl15s73cvimib3asgbqsbfrccq0z7cw-golangci-lint-1.58.1"
         }
       }
     },
     "golines@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#golines",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#golines",
       "source": "devbox-search",
       "version": "0.12.2",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/k8jwj5j1x1z5yh7plk3z7pvad9nsr2l4-golines-0.12.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cmpb524hb7f511x0kqlcvv2n6nbydp5r-golines-0.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cmpb524hb7f511x0kqlcvv2n6nbydp5r-golines-0.12.2"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/1b2gkq7ws4d5pnfb1barr5zan6qn3sb2-golines-0.12.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5mkhh6pqskcrwrk4n0ij9bqg4sbnhzim-golines-0.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5mkhh6pqskcrwrk4n0ij9bqg4sbnhzim-golines-0.12.2"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/nbp6p8shvd5fldx1jp5s56mzw37m030y-golines-0.12.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1fbyc0x8773jxy1bbhadn6p9hrs4s06p-golines-0.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1fbyc0x8773jxy1bbhadn6p9hrs4s06p-golines-0.12.2"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/anlc07pmbhzja0kqb1ffdc98y365fkb4-golines-0.12.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kjsc50imaqvxhs226skh1q3nl5qjywaq-golines-0.12.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kjsc50imaqvxhs226skh1q3nl5qjywaq-golines-0.12.2"
         }
       }
     },
     "gosec@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#gosec",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#gosec",
       "source": "devbox-search",
       "version": "2.19.0",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/pcam14m8yvngzzxgx4whkyvbc47w86hs-gosec-2.19.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dfiq2k5masmar0wza1gs6b09g0d6xckn-gosec-2.19.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/dfiq2k5masmar0wza1gs6b09g0d6xckn-gosec-2.19.0"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/75plc22nzfp9m3wxcbnpw0b3bp3glzs1-gosec-2.19.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6c0hr6q7vnvw3b48x3l8v7q4zfwvsssb-gosec-2.19.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6c0hr6q7vnvw3b48x3l8v7q4zfwvsssb-gosec-2.19.0"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/wgxw2dghwyh4bm73z5kwdnsy94r6mnac-gosec-2.19.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xafwmzwjj7hsysj81907x2f201b5iwh7-gosec-2.19.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/xafwmzwjj7hsysj81907x2f201b5iwh7-gosec-2.19.0"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/kiga4jm15whxv3lpjsw7y884y4kfa8x8-gosec-2.19.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4jsvpk1gyp40jcpcnfy667yain6ih0al-gosec-2.19.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/4jsvpk1gyp40jcpcnfy667yain6ih0al-gosec-2.19.0"
         }
       }
     },
     "gotools@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#gotools",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#gotools",
       "source": "devbox-search",
       "version": "0.18.0",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/a521fr0vkk44iz5qvgxayalnal0n3587-gotools-0.18.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i90kx57qmzqx8yhrr2aw7l7pinyjikpd-gotools-0.18.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i90kx57qmzqx8yhrr2aw7l7pinyjikpd-gotools-0.18.0"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/mzsgx657953ijf5afm3cil2x92xlva2b-gotools-0.18.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6y77lsv0fissa4sy1ymxrkvbk156hpf0-gotools-0.18.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6y77lsv0fissa4sy1ymxrkvbk156hpf0-gotools-0.18.0"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/igx2vwhs2grswg7q6ngyfyidahmdfac9-gotools-0.18.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fk2c6gyslrf13yikhlg8krw61mabs7w6-gotools-0.18.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fk2c6gyslrf13yikhlg8krw61mabs7w6-gotools-0.18.0"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/j7zzwc034s4gzfg33i8pxswrhb1li08b-gotools-0.18.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mxr26sym3dc7lx1vna699ls5awms4z10-gotools-0.18.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mxr26sym3dc7lx1vna699ls5awms4z10-gotools-0.18.0"
         }
       }
     },
     "govulncheck@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#govulncheck",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#govulncheck",
       "source": "devbox-search",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/w6n78s03arv75ymqhzb4lgbi3kx5kx5x-govulncheck-1.0.4"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pd3if62b0a23pm417pdl1fzh825z853w-govulncheck-1.1.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pd3if62b0a23pm417pdl1fzh825z853w-govulncheck-1.1.0"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/vzmbb40a0xy6hr9zw6r4jqhy786qpiaz-govulncheck-1.0.4"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b2isww1wbvz2g2ml2q5sfkadx17i3bxy-govulncheck-1.1.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/b2isww1wbvz2g2ml2q5sfkadx17i3bxy-govulncheck-1.1.0"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/zgcyah07vgd222pw8lksr7d4mys2gx1d-govulncheck-1.0.4"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7j6hpj4ldkhm8g4r8p0bq3n798sr8f3x-govulncheck-1.1.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7j6hpj4ldkhm8g4r8p0bq3n798sr8f3x-govulncheck-1.1.0"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/6lxqgj80bhikfq3a9azk6mfrlskb4rv2-govulncheck-1.0.4"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gq2y6nqvxykwby2vg9bhsq1bsxqwv46l-govulncheck-1.1.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gq2y6nqvxykwby2vg9bhsq1bsxqwv46l-govulncheck-1.1.0"
         }
       }
     },
     "mockgen@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#mockgen",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#mockgen",
       "source": "devbox-search",
       "version": "0.4.0",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/3nw7c0fscwdm8qcdvwn7y9djardxcvhv-mockgen-0.4.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/w2gk19gal3czasap2afp9sy9g9a246nb-mockgen-0.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/w2gk19gal3czasap2afp9sy9g9a246nb-mockgen-0.4.0"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/bawjym80grb3zxb765v9jhxln4h53nrm-mockgen-0.4.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gn0vq6x4h834gihqbggq2yix2lw91n30-mockgen-0.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gn0vq6x4h834gihqbggq2yix2lw91n30-mockgen-0.4.0"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/35v516vnv5wywkim0g79ik20gifks5b7-mockgen-0.4.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7b2qhyc38y1i5760rwv11xk21g8bsrz9-mockgen-0.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7b2qhyc38y1i5760rwv11xk21g8bsrz9-mockgen-0.4.0"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/viq8fww9vh72i8b5s8yg4j801h1k31ws-mockgen-0.4.0"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cddy5gvgs2ny66m4da1x32w152qp9ghs-mockgen-0.4.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cddy5gvgs2ny66m4da1x32w152qp9ghs-mockgen-0.4.0"
         }
       }
     },
     "yarn@latest": {
-      "last_modified": "2024-03-22T11:26:23Z",
-      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#yarn",
+      "last_modified": "2024-05-12T16:19:40Z",
+      "resolved": "github:NixOS/nixpkgs/3281bec7174f679eabf584591e75979a258d8c40#yarn",
       "source": "devbox-search",
       "version": "1.22.22",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/7rv0zj74rm049vchr7c4hiisw4pigs85-yarn-1.22.22"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mab0xq8q3rg2hay9hmjy46cwbx6f02qj-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mab0xq8q3rg2hay9hmjy46cwbx6f02qj-yarn-1.22.22"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/8wq8jz5dbq1q3gdnh22d47bf79fkaasy-yarn-1.22.22"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vki75aknvjbnncb14zcgz22j97pkw2ki-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vki75aknvjbnncb14zcgz22j97pkw2ki-yarn-1.22.22"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/mp2xyil9p9d1fva75zr0phxbv7312avr-yarn-1.22.22"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wsq0sxvj6lcc9d2ias1zc5i5sh7dnsk0-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wsq0sxvj6lcc9d2ias1zc5i5sh7dnsk0-yarn-1.22.22"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/aivn7biys6sbiq9rnpclbk1l81sqk2pa-yarn-1.22.22"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zymyy63y8s15rzd138w76qkd2v1m9nf7-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zymyy63y8s15rzd138w76qkd2v1m9nf7-yarn-1.22.22"
         }
       }
     }


### PR DESCRIPTION
`govulncheck` reports tend to block merges even when vulnerability has been already present in the current version of the code, most of the time detected in the Go code itself.
Due to the fact that we're not always able to bump the version of Go to the latest patch OR there the vulnerability might not yet have a patch version, I decided to turn it off and only run it on schedule, but not block merges with it.
For code based vulns we have both the linter and gosec anyway.