### PR TITLE
chore: Add markdownlint config

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,10 @@
+MD010:
+  code_blocks: false
+  spaces_per_tab: 1
+MD013:
+  line_length: 80
+  heading_line_length: 80
+  code_block_line_length: 120
+  code_blocks: true
+MD024:
+  siblings_only: true

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ check/trailing:
 ## Check markdown files for potential issues with markdownlint.
 check/markdown:
 	$(call _print_step,Verifying Markdown files)
-	yarn --silent markdownlint '*.md' --disable MD010, MD034 # MD010 does not handle code blocks well.
+	yarn --silent markdownlint '**/*.md' --ignore node_modules
 
 ## Check for potential vulnerabilities across all Go dependencies.
 check/vulns:

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Example:
 
 ### Module sources
 
-| Source      | Flag      | Example                                                               |
-|-------------|-----------|-----------------------------------------------------------------------|
-| File path   | _default_ | ~/my-project/go.mod                                                   |
-| URL         | `--url`   | https://raw.githubusercontent.com/nieomylnieja/go-libyear/main/go.mod |
-| Module path | `--pkg`   | github.com/nieomylnieja/go-libyear@latest                             |
+| Source      | Flag      | Example                                                                                                         |
+|-------------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| File path   | _default_ | ~/my-project/go.mod                                                                                             |
+| URL         | `--url`   | https://raw.githubusercontent.com/nieomylnieja/go-libyear/main/go.mod  <!-- markdownlint-disable-line MD034 --> |
+| Module path | `--pkg`   | github.com/nieomylnieja/go-libyear@latest                                                                       |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -219,7 +219,7 @@ it will drop the following error:
 updates to go.sum needed, disabled by -mod=readonly
 ```
 
-Due to that it is advised to use stick with default modules information
+Due to that it is advised to stick with default modules information
 provider.
 
 ## Development
@@ -234,8 +234,8 @@ CLI tests.
 
 Inspired directly
 by [SE Radio episode 587](https://www.se-radio.net/2023/10/se-radio-587-m-scott-ford-on-managing-dependency-freshness/).
-Further reading through https://libyear.com/ and
-mimicking https://github.com/jaredbeck/libyear-bundler capabilities.
+Further reading through [libyear.com](https://libyear.com/) and
+mimicking [libyear-bundler](https://github.com/jaredbeck/libyear-bundler) capabilities.
 
 All the concepts and theory is based
 on or directly quoted

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "devDependencies": {
     "cspell": "8.8.1",
-    "markdownlint-cli": "0.39.0",
+    "markdownlint-cli": "0.40.0",
     "yaml": "2.4.2"
   },
   "scripts": {


### PR DESCRIPTION
Adds markdownlint config for better control of Markdown files linting.