### PR TITLE
feat: Add GHCR Docker release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*'
 jobs:
-  build:
+  binary:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
@@ -23,3 +23,38 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{secrets.GORELEASER_TOKEN}}
+  image:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN CGO_ENABLED=0 go build \
 
 FROM scratch
 
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.authors="nieomylnieja"
+LABEL org.opencontainers.image.title="go-libyear"
+LABEL org.opencontainers.image.description="Calculate Go module's libyear"
+LABEL org.opencontainers.image.source="https://github.com/nieomylnieja/go-libyear"
+
 COPY --from=builder /artifacts/go-libyear ./go-libyear
 
 ENTRYPOINT ["./go-libyear"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ make build
 ./bin/go-libyear ./go.mod
 ```
 
+### Docker
+
+Docker images hosted on GitHub Container Registry are also provided:
+
+```shell
+docker pull ghcr.io/nieomylnieja/go-libyear:latest
+```
+
 ## Usage
 
 `go-libyear` can be used both as a CLI and Go library.

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -39,6 +39,7 @@ words:
   - govulncheck
   - ifeq
   - ldflags
+  - nieomylnieja
   - procs
   - strs
   - vuln


### PR DESCRIPTION
Adds packaging for GitHub Container Registry.
The Docker image will not be published there with each release.