### PR TITLE
fix(Dockerfile): Switch from scratch to distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 go build \
   -o /artifacts/go-libyear \
   "${PWD}/cmd/go-libyear"
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL org.opencontainers.image.authors="nieomylnieja"

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -25,6 +25,7 @@ ignorePaths:
   - bin/**
   - test/**
 words:
+  - distroless
   - endef
   - gobin
   - gofumpt


### PR DESCRIPTION
Currently the docker image is not really working as we're missing certs to run HTTP requests.
We could add them manually, installing with apk and then copying, but it'll be easier to just use [distroless](https://github.com/GoogleContainerTools/distroless) image which comes all-inclusive.