### PR TITLE
fix(release.yml): Correct tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Get tag name
+        id: tag
+        run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v5
@@ -62,7 +65,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            LDFLAGS=-s -w -X main.BuildVersion=${{ github.ref }} -X main.BuildGitTag=${{ github.ref }} -X main.BuildDate=${{ steps.date.outputs.date }}
+            LDFLAGS=-s -w -X main.BuildVersion=${{ steps.tag.outputs.tag }} -X main.BuildGitTag=${{ steps.tag.outputs.tag }} -X main.BuildDate=${{ steps.date.outputs.date }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:


### PR DESCRIPTION
`GITHUB_REF` provides a fully qualified git ref name which ends up being `refs/tags/v0.4.5`.
Instead we only want the tag name itself.