### PR TITLE
fix: handle invalid goproxy latest versions

### DIFF
--- a/internal/go_proxy.go
+++ b/internal/go_proxy.go
@@ -2,12 +2,14 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -58,7 +60,18 @@ func (c *GoProxyClient) GetInfo(path string, version *semver.Version) (*Module, 
 }
 
 func (c *GoProxyClient) GetLatestInfo(path string) (*Module, error) {
-	return c.getInfo(path, nil, true)
+	m, err := c.getInfo(path, nil, true)
+	if err == nil {
+		return m, nil
+	}
+	if !isProxyNotFound(err) {
+		return nil, err
+	}
+	m, fallbackErr := c.getLatestInfoFromVersions(path)
+	if fallbackErr != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func (c *GoProxyClient) getInfo(path string, version *semver.Version, latest bool) (*Module, error) {
@@ -115,6 +128,29 @@ func (c *GoProxyClient) GetVersions(path string) ([]*semver.Version, error) {
 	return versions, nil
 }
 
+func (c *GoProxyClient) getLatestInfoFromVersions(path string) (*Module, error) {
+	versions, err := c.GetVersions(path)
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(semver.Collection(versions))
+	var latestErr error
+	for i := len(versions) - 1; i >= 0; i-- {
+		m, err := c.GetInfo(path, versions[i])
+		if err == nil {
+			return m, nil
+		}
+		if !isProxyNotFound(err) {
+			return nil, err
+		}
+		latestErr = err
+	}
+	if latestErr != nil {
+		return nil, latestErr
+	}
+	return nil, fmt.Errorf("no versions found for path %s", path)
+}
+
 func (c *GoProxyClient) GetModFile(path string, version *semver.Version) ([]byte, error) {
 	urlPath := fmt.Sprintf(getModFileFmt, escapePath(path), version)
 	return c.query(urlPath)
@@ -125,14 +161,39 @@ func (c *GoProxyClient) query(urlPath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		data, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf(
-			"unexpected response status code from %s %s: %d, body: %s",
-			http.MethodGet, resp.Request.URL.String(), resp.StatusCode, string(data))
+		return nil, &proxyResponseError{
+			method:     http.MethodGet,
+			url:        resp.Request.URL.String(),
+			statusCode: resp.StatusCode,
+			body:       string(data),
+		}
 	}
-	defer func() { _ = resp.Body.Close() }()
 	return io.ReadAll(resp.Body)
+}
+
+type proxyResponseError struct {
+	method     string
+	url        string
+	statusCode int
+	body       string
+}
+
+func (e *proxyResponseError) Error() string {
+	return fmt.Sprintf(
+		"unexpected response status code from %s %s: %d, body: %s",
+		e.method, e.url, e.statusCode, e.body)
+}
+
+func isProxyNotFound(err error) bool {
+	var responseErr *proxyResponseError
+	if !errors.As(err, &responseErr) {
+		return false
+	}
+	return responseErr.statusCode == http.StatusNotFound ||
+		responseErr.statusCode == http.StatusGone
 }
 
 var uppercaseRegex = regexp.MustCompile(`[A-Z]`)

--- a/internal/go_proxy_test.go
+++ b/internal/go_proxy_test.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoProxyClient_GetLatestInfo_FallbackToVersionList(t *testing.T) {
+	t.Parallel()
+
+	client := newTestGoProxyClient(t, func(r *http.Request) (int, string) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/@latest"):
+			return http.StatusNotFound, invalidGoSQLMockVersion
+		case strings.HasSuffix(r.URL.Path, "/@v/list"):
+			return http.StatusOK, "v1.3.0\nv1.5.2\n"
+		case strings.HasSuffix(r.URL.Path, "/@v/v1.5.2.info"):
+			return http.StatusNotFound, invalidGoSQLMockVersion
+		case strings.HasSuffix(r.URL.Path, "/@v/v1.3.0.info"):
+			return http.StatusOK, `{"Version":"v1.3.0","Time":"2017-09-01T07:34:10Z"}`
+		default:
+			return http.StatusNotFound, "not found"
+		}
+	})
+
+	module, err := client.GetLatestInfo("gopkg.in/DATA-DOG/go-sqlmock.v1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "gopkg.in/DATA-DOG/go-sqlmock.v1", module.Path)
+	assert.Equal(t, semver.MustParse("v1.3.0"), module.Version)
+}
+
+func TestGoProxyClient_GetLatestInfo_DoesNotFallbackForServerError(t *testing.T) {
+	t.Parallel()
+
+	client := newTestGoProxyClient(t, func(_ *http.Request) (int, string) {
+		return http.StatusInternalServerError, "server error\n"
+	})
+
+	_, err := client.GetLatestInfo("gopkg.in/DATA-DOG/go-sqlmock.v1")
+
+	require.EqualError(
+		t,
+		err,
+		"unexpected response status code from GET "+
+			"https://proxy.test/gopkg.in%2F%21d%21a%21t%21a-%21d%21o%21g%2Fgo-sqlmock.v1/@latest: "+
+			"500, body: server error\n",
+	)
+}
+
+const invalidGoSQLMockVersion = `not found: gopkg.in/DATA-DOG/go-sqlmock.v1@v1.5.2: ` +
+	`invalid version: go.mod has non-....v1 module path ` +
+	`"github.com/DATA-DOG/go-sqlmock" at revision v1.5.2`
+
+func newTestGoProxyClient(
+	t *testing.T,
+	handler func(*http.Request) (int, string),
+) GoProxyClient {
+	t.Helper()
+
+	u, err := url.Parse("https://proxy.test")
+	require.NoError(t, err)
+	return GoProxyClient{
+		http: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				statusCode, body := handler(r)
+				return &http.Response{
+					StatusCode: statusCode,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Request:    r,
+				}, nil
+			}),
+		},
+		apiURL: *u,
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}


### PR DESCRIPTION
## Motivation

Scanning one of the repositories failed because GOPROXY's `@latest` endpoint for `gopkg.in/DATA-DOG/go-sqlmock.v1` resolves to `v1.5.2`, whose `go.mod` declares `github.com/DATA-DOG/go-sqlmock`. go-libyear should still resolve the newest valid version for the legacy `gopkg.in` module path instead of failing the whole scan.

## Summary

Added a GOPROXY `@latest` fallback for 404 and 410 responses that read the version list and selected the newest version with valid `.info` metadata.
Preserved non-not-found proxy errors and the existing response error text.

## Testing

Covered the invalid `go-sqlmock` `@latest` case with a unit test and kept a server-error test to verify non-not-found responses did not fall back.
Verified a temporary `go.mod` containing `gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0` resolved latest as `1.3.0` against the real Go proxy.

## Release Notes

Fixed scans for legacy `gopkg.in` module paths when GOPROXY `@latest` pointed at an incompatible module path, allowing go-libyear to use the newest valid version instead of failing.
