### PR TITLE
feat: discover go.mod when path is omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It can also be built directly from this repository:
 git clone https://github.com/nieomylnieja/go-libyear.git
 cd go-libyear
 just build
-./bin/go-libyear ./go.mod
+./bin/go-libyear
 ```
 
 ### Docker
@@ -43,7 +43,7 @@ and accessed through `go-libyear --help`.
 Basic usage:
 
 ```shell
-$ go-libyear /path/to/go.mod
+$ go-libyear
 package                             version  date        latest   latest_date  libyear
 github.com/nieomylnieja/go-libyear           2023-11-06                        2.41
 github.com/Masterminds/semver       v1.4.2   2019-04-07  v1.5.0   2021-09-14   2.44
@@ -128,7 +128,7 @@ Example:
 
 | Source      | Flag      | Example                                                                                                         |
 |-------------|-----------|-----------------------------------------------------------------------------------------------------------------|
-| File path   | _default_ | ~/my-project/go.mod                                                                                             |
+| File path   | _default_ | Omit to discover the nearest `go.mod` before the Git boundary, or pass `~/my-project/go.mod`.                   |
 | URL         | `--url`   | https://raw.githubusercontent.com/nieomylnieja/go-libyear/main/go.mod  <!-- markdownlint-disable-line MD034 --> |
 | Module path | `--pkg`   | github.com/nieomylnieja/go-libyear@latest                                                                       |
 

--- a/cmd/go-libyear/main.go
+++ b/cmd/go-libyear/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -77,6 +78,13 @@ func run(cliCtx *cli.Context) error {
 
 	var source golibyear.Source
 	sourceArg := cliCtx.Args().Get(0)
+	if sourceArg == "" && !stdinUsed {
+		var err error
+		sourceArg, err = defaultGoModPath()
+		if err != nil {
+			return err
+		}
+	}
 	switch {
 	case cliCtx.IsSet(flagPkg.Name):
 		source = &golibyear.PkgSource{Pkg: sourceArg}
@@ -149,12 +157,15 @@ func setupContextHandling(cliCtx *cli.Context) (ctx context.Context, handler fun
 }
 
 func validateArgs(cliCtx *cli.Context, stdinUsed bool) error {
-	if cliCtx.NArg() != 1 && !stdinUsed {
-		return errors.New("invalid number of arguments provided, expected a single argument, path to go.mod")
-	}
 	if stdinUsed && (cliCtx.NArg() != 0 || cliCtx.IsSet(flagURL.Name) || cliCtx.IsSet(flagPkg.Name)) {
 		return fmt.Errorf(
 			"when reading go.mod from stdin no arguments or output related flags should be provided")
+	}
+	if cliCtx.NArg() > 1 {
+		return errors.New("invalid number of arguments provided, expected at most one argument, path to go.mod")
+	}
+	if !stdinUsed && cliCtx.NArg() == 0 && (cliCtx.IsSet(flagURL.Name) || cliCtx.IsSet(flagPkg.Name)) {
+		return errors.New("invalid number of arguments provided, expected a source argument")
 	}
 
 	for _, flags := range [][]string{
@@ -167,6 +178,58 @@ func validateArgs(cliCtx *cli.Context, stdinUsed bool) error {
 		}
 	}
 	return nil
+}
+
+func defaultGoModPath() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return findGoModPath(wd)
+}
+
+func findGoModPath(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute path for %s: %w", start, err)
+	}
+	for {
+		goModPath := filepath.Join(dir, "go.mod")
+		info, err := os.Stat(goModPath)
+		switch {
+		case err == nil && info.IsDir():
+			return "", fmt.Errorf("%s is a directory, expected go.mod file", goModPath)
+		case err == nil:
+			return goModPath, nil
+		case !errors.Is(err, os.ErrNotExist):
+			return "", fmt.Errorf("stat %s: %w", goModPath, err)
+		}
+
+		gitBoundary, err := isGitBoundary(dir)
+		if err != nil {
+			return "", err
+		}
+		if gitBoundary {
+			return "", fmt.Errorf("could not find go.mod before reaching git boundary at %s", dir)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find go.mod from %s or any parent directory", start)
+		}
+		dir = parent
+	}
+}
+
+func isGitBoundary(dir string) (bool, error) {
+	gitPath := filepath.Join(dir, ".git")
+	if _, err := os.Stat(gitPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s: %w", gitPath, err)
+	}
+	return true, nil
 }
 
 func isStdinUsed() bool {

--- a/cmd/go-libyear/main_test.go
+++ b/cmd/go-libyear/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_findGoModPath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setup func(t *testing.T, root string) (start, expected, expectedErr string)
+	}{
+		"current directory": {
+			setup: func(t *testing.T, root string) (string, string, string) {
+				t.Helper()
+
+				writeFile(t, filepath.Join(root, "go.mod"), "module example.com/current\n")
+				return root, filepath.Join(root, "go.mod"), ""
+			},
+		},
+		"parent directory": {
+			setup: func(t *testing.T, root string) (string, string, string) {
+				t.Helper()
+
+				start := filepath.Join(root, "child", "nested")
+				mkdirAll(t, start)
+				writeFile(t, filepath.Join(root, "go.mod"), "module example.com/parent\n")
+				return start, filepath.Join(root, "go.mod"), ""
+			},
+		},
+		"git boundary containing go.mod": {
+			setup: func(t *testing.T, root string) (string, string, string) {
+				t.Helper()
+
+				start := filepath.Join(root, "child", "nested")
+				mkdirAll(t, start)
+				writeFile(t, filepath.Join(root, ".git"), "gitdir: ../.git/worktrees/example\n")
+				writeFile(t, filepath.Join(root, "go.mod"), "module example.com/repo\n")
+				return start, filepath.Join(root, "go.mod"), ""
+			},
+		},
+		"nested git boundary without go.mod": {
+			setup: func(t *testing.T, root string) (string, string, string) {
+				t.Helper()
+
+				repo := filepath.Join(root, "repo")
+				nestedRepo := filepath.Join(repo, "nested")
+				start := filepath.Join(nestedRepo, "child")
+				mkdirAll(t, start)
+				writeFile(t, filepath.Join(repo, "go.mod"), "module example.com/outer\n")
+				writeFile(t, filepath.Join(nestedRepo, ".git"), "gitdir: ../.git/modules/nested\n")
+				return start, "", "could not find go.mod before reaching git boundary at " + nestedRepo
+			},
+		},
+		"go.mod directory": {
+			setup: func(t *testing.T, root string) (string, string, string) {
+				t.Helper()
+
+				mkdirAll(t, filepath.Join(root, "go.mod"))
+				return root, "", filepath.Join(root, "go.mod") + " is a directory"
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			start, expected, expectedErr := tt.setup(t, t.TempDir())
+			actual, err := findGoModPath(start)
+			if expectedErr != "" {
+				require.ErrorContains(t, err, expectedErr)
+				assert.Empty(t, actual)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func mkdirAll(t *testing.T, path string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(path, 0o750))
+}
+
+func writeFile(t *testing.T, path, data string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+}

--- a/cmd/go-libyear/usage.txt
+++ b/cmd/go-libyear/usage.txt
@@ -1,11 +1,12 @@
-go-libyear [flags] <path>
+go-libyear [flags] [path]
 
 Calculate Go module's libyear!
 
 There are multiple ways to parse selected go.mod file.
 Reading go.mod from the following sources is supported:
   - file [default]: file path to a go.mod file
-    example: ./go.mod, /home/user/project/go.mod
+    if omitted, go-libyear searches from the current directory upward until it finds go.mod or reaches a Git boundary
+    example: go-libyear, go-libyear ./go.mod, go-libyear /home/user/project/go.mod
   - url: URL from which to fetch the file; the request is a simple GET
     example: https://raw.githubusercontent.com/nieomylnieja/go-libyear/main/go.mod
   - pkg: Go pkg name; if no version is provided, @latest will be appended to the name

--- a/test/test.bats
+++ b/test/test.bats
@@ -72,6 +72,19 @@ setup() {
 	assert_output_equals basic_usage
 }
 
+@test "go_proxy: default source discovers parent go.mod" {
+	project="$BATS_TEST_TMPDIR/default-source"
+	mkdir -p "$project/nested"
+	cp "$TEST_GO_MOD" "$project/go.mod"
+
+	pushd "$project/nested" >/dev/null
+	run go-libyear
+	popd >/dev/null
+
+	assert_success
+	assert_output_equals basic_usage
+}
+
 @test "go_proxy: show versions" {
 	run go-libyear --versions "$TEST_GO_MOD"
 	assert_success
@@ -228,10 +241,10 @@ EOF
 	assert_output "Error: open ./fake-path: no such file or directory"
 }
 
-@test "error: no path" {
+@test "error: no discovered go.mod" {
 	run go-libyear
 	assert_failure
-	assert_output "Error: invalid number of arguments provided, expected a single argument, path to go.mod"
+	assert_output --partial "Error: could not find go.mod"
 }
 
 @test "error: stdin with forbidden args" {


### PR DESCRIPTION
## Motivation

`go-libyear` currently requires callers to always pass a `go.mod` path. Running it without arguments should be convenient from any directory inside a Go module, while still stopping at a Git boundary instead of scanning across repositories.

## Summary

Added default file-source discovery that walks upward from the current directory until it finds `go.mod` or reaches a Git boundary.

Updated argument validation so pathless execution is valid for the default file source while URL and package sources still require an explicit source.

Updated CLI help and README examples to document the optional path.

## Testing

Added unit coverage for current-directory discovery, parent-directory discovery, Git-boundary stopping, and invalid `go.mod` directory handling.

Added CLI coverage for running `go-libyear` without arguments from a nested directory.

## Release Notes

Added support for running `go-libyear` without a source argument when using the default file source. The command now discovers the nearest `go.mod` by walking upward from the current directory and stops at Git boundaries.
